### PR TITLE
Don't require meck directly.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -11,7 +11,6 @@
  [
   {lager, ".*", {git, "git://github.com/basho/lager.git", {tag,"2.0.3"}}},
   {parse_trans, ".*", {git, "git://github.com/uwiger/parse_trans.git", {tag,"2.9"}}},
-  {meck, "0.8.1", {git, "git://github.com/eproxus/meck.git", {tag,"0.8.1"}}},
   {folsom, "0.7.4p4", {git, "git://github.com/basho/folsom.git", {tag, "0.7.4p4"}}},
   {setup, ".*", {git, "git://github.com/uwiger/setup.git", {tag,"1.4"}}}
  ]}.


### PR DESCRIPTION
Exometer core uses basho/folsom, which has it's own dependency on a meck
which is in the basho organization, not the eproxus one.