### PR TITLE
basho-otp-18 compatibility

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -10,7 +10,7 @@
 {deps,
  [
   {lager, ".*", {git, "git://github.com/basho/lager.git", {tag,"2.0.3"}}},
-  {parse_trans, ".*", {git, "git://github.com/uwiger/parse_trans.git", {tag,"2.9"}}},
+  {parse_trans, ".*", {git, "git://github.com/uwiger/parse_trans.git", {tag,"2.9.2"}}},
   {folsom, "0.7.4p5", {git, "git://github.com/basho/folsom.git", {tag, "0.7.4p5"}}},
   {setup, ".*", {git, "git://github.com/uwiger/setup.git", {tag,"1.4"}}}
  ]}.

--- a/src/exometer_uniform.erl
+++ b/src/exometer_uniform.erl
@@ -55,7 +55,7 @@ probe_init(Name, _Type, Options) ->
 
     %% Setup random seed, if not already done.
     case get(random_seed) of
-        undefined -> random:seed(now());
+        undefined -> random:seed(os:timestamp());
         _ -> true
     end,
     {ok, St#st{ ets_ref = EtsRef }}.


### PR DESCRIPTION
Make exometer_core work in OTP 18.

Update to parse_trans version 2.9.2 to get a version of edown that has been fixed for the removal in OTP 18.0 of the edoc doclet_gen.packages and doclet_gen.filemap record fields.

Change erlang:now() to os:timestamp(), to eliminate the "Deprecated BIF" warning in OTP 18.0.

The modified exometer_core application passes "make test" in [basho/otp](https://github.com/basho/otp) branches [basho-otp-16](https://github.com/basho/otp/tree/basho-otp-16), [basho-otp-17](https://github.com/basho/otp/tree/basho-otp-17), and [basho-otp-18](https://github.com/basho/otp/tree/basho-otp-18). "TEST COMPLETE, 19 ok, 0 failed of 19 test cases"
