### PR TITLE
Bumped lager dependency.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
 
 {deps,
  [
-  {lager, ".*", {git, "git://github.com/basho/lager.git", {tag,"2.0.3"}}},
+  {lager, ".*", {git, "git://github.com/basho/lager.git", {tag,"2.2.0"}}},
   {parse_trans, ".*", {git, "git://github.com/uwiger/parse_trans.git", {tag,"2.9"}}},
   {folsom, "0.7.4p5", {git, "git://github.com/basho/folsom.git", {tag, "0.7.4p5"}}},
   {setup, ".*", {git, "git://github.com/uwiger/setup.git", {tag,"1.4"}}}


### PR DESCRIPTION
Bumped lager dependency so it won't conflict with other dependencies of riak_core. Those dependencies are upgraded for compatibility with Erlang 18, so this should probably be merged at the same time as this one: https://github.com/basho/exometer_core/pull/7.