### PR TITLE
Merge riak_ts-develop into develop-2.2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,10 +9,10 @@
 
 {deps,
  [
-  {lager, ".*", {git, "git://github.com/basho/lager.git", {tag,"2.0.3"}}},
+  {lager, "(2.0|2.1|2.2).*", {git, "git://github.com/basho/lager.git", {tag,"2.2.0"}}},
   {parse_trans, ".*", {git, "git://github.com/uwiger/parse_trans.git", {tag,"2.9"}}},
   {folsom, "0.7.4p5", {git, "git://github.com/basho/folsom.git", {tag, "0.7.4p5"}}},
-  {setup, ".*", {git, "git://github.com/uwiger/setup.git", {tag,"1.4"}}}
+  {setup, ".*", {git, "git://github.com/basho/setup.git", {tag, "1.5-basho2"}}}
  ]}.
 
 {erl_opts,


### PR DESCRIPTION
This is a repeat of #12. I foolishly did a squash merge, which will cause ugliness down the line if/when we try to merge in more changes from riak_ts-develop. I already force updated the develop-2.2 branch to undo that squash merge. Since #12 was already +1'd and merged, I'm just going to go ahead and merge this as well once it's created, but do a normal merge this time.